### PR TITLE
Added Elastic Beanstalk configuration for serving static files

### DIFF
--- a/.ebextensions/static-files.cfg.yml
+++ b/.ebextensions/static-files.cfg.yml
@@ -1,0 +1,5 @@
+option_settings:
+  aws:elasticbeanstalk:container:nodejs:staticfiles:
+    /public: /public
+    /html: /static/html
+    /images: /static/images


### PR DESCRIPTION
Adds EB configuration file that tells the Nginx reverse proxy to serve static files directly instead of asking the app to serve them.